### PR TITLE
Fix building Leetmouse against kernel 5.19 headers

### DIFF
--- a/driver/usbmouse.c
+++ b/driver/usbmouse.c
@@ -24,6 +24,7 @@
 #include <linux/init.h>
 #include <linux/usb/input.h>
 #include <linux/hid.h>
+#include <generated/uapi/linux/version.h>
 
 /* for apple IDs */
 /*                                                              //Leetmouse Mod BEGIN
@@ -180,7 +181,11 @@ static int usb_mouse_probe(struct usb_interface *intf, const struct usb_device_i
         return -ENODEV;
 
     pipe = usb_rcvintpipe(dev, endpoint->bEndpointAddress);
-    maxp = usb_maxpacket(dev, pipe, usb_pipeout(pipe));
+	#if LINUX_VERSION_CODE < KERNEL_VERSION(5,19,0)
+    	maxp = usb_maxpacket(dev, pipe, usb_pipeout(pipe));
+	#else
+    	maxp = usb_maxpacket(dev, pipe);
+	#endif
 
     mouse = kzalloc(sizeof(struct usb_mouse), GFP_KERNEL);
     input_dev = input_allocate_device();

--- a/driver/usbmouse.c
+++ b/driver/usbmouse.c
@@ -181,11 +181,11 @@ static int usb_mouse_probe(struct usb_interface *intf, const struct usb_device_i
         return -ENODEV;
 
     pipe = usb_rcvintpipe(dev, endpoint->bEndpointAddress);
-	#if LINUX_VERSION_CODE < KERNEL_VERSION(5,19,0)
-    	maxp = usb_maxpacket(dev, pipe, usb_pipeout(pipe));
-	#else
-    	maxp = usb_maxpacket(dev, pipe);
-	#endif
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(5,19,0)
+        maxp = usb_maxpacket(dev, pipe, usb_pipeout(pipe));
+    #else
+        maxp = usb_maxpacket(dev, pipe);
+    #endif
 
     mouse = kzalloc(sizeof(struct usb_mouse), GFP_KERNEL);
     input_dev = input_allocate_device();


### PR DESCRIPTION
I upgraded my kernel to 5.19 and saw that Leetmouse failed to build, so I decided to try fixing it. This patch fixes the build on kernel 5.19 in a backwards compatible manner. I made it in 20 minutes, and I don't know if this is a good way of using different code paths for different kernel versions. I have tested that it builds for kernel versions 5.18 and 5.19 on Arch Linux. I also tested that mouse accel works on 5.19 with this patch.