### PR TITLE
Fix bind script shebang

### DIFF
--- a/scripts/bind.sh
+++ b/scripts/bind.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # TODO This proof-of-concept bind script will be replaced by a more mainstreamed udev rule in the near future.
 


### PR DESCRIPTION
the script uses bashisms and does not work on systems where /bin/sh is not bash