### PR TITLE
Makefile fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ driver_install:
 	@echo -e "\n::\033[34m Installing leetmouse kernel module\033[0m"
 	@echo "====================================================="
 	@mkdir -p $(DESTDIR)/$(MODULEDIR)
-	@cp -v $(DRIVERDIR)/*.ko $(DESTDIR)/$(MODULEDIR)
-	@chown -v root:root $(DESTDIR)/$(MODULEDIR)/*.ko
+	@cp -v $(DRIVERDIR)/leetmouse.ko $(DESTDIR)/$(MODULEDIR)
+	@chown -v root:root $(DESTDIR)/$(MODULEDIR)/leetmouse.ko
 	depmod
 
 # Remove kernel modules

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ driver_clean:
 driver_install:
 	@echo -e "\n::\033[34m Installing leetmouse kernel module\033[0m"
 	@echo "====================================================="
+	@mkdir -p $(DESTDIR)/$(MODULEDIR)
 	@cp -v $(DRIVERDIR)/*.ko $(DESTDIR)/$(MODULEDIR)
 	@chown -v root:root $(DESTDIR)/$(MODULEDIR)/*.ko
 	depmod


### PR DESCRIPTION
Fixes `driver_install` when the usb dir doesn't exist and removes use of glob to avoid any unintended side-effects.